### PR TITLE
Only run CI when needed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 on:
   pull_request:
+    paths:
+    - Tiltfile
+    - .github/workflows/test.yaml
   merge_group:
 
 jobs:


### PR DESCRIPTION
Only run CI if Tiltfile or the test workflow change.