### PR TITLE
Fixes entrypoint for docker_build_with_restart

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -41,9 +41,9 @@ CGO_ENABLED=0 GOOS=linux go build {gcflags} -o .tiltbuild/bin/{binary} ./cmd/{bi
         deps=['api', 'cmd/{}'.format(binary), 'internal', 'pkg', 'go.mod', 'go.sum']
     )
 
-    entrypoint = '/{}'.format(binary)
+    entrypoint = ['/{}'.format(binary)]
     if debug:
-        entrypoint = '/dlv --accept-multiclient --api-version=2 --headless=true --listen :30000 exec --continue -- ' + entrypoint
+        entrypoint = ['/dlv', '--accept-multiclient', '--api-version=2', '--headless=true', '--listen', ':30000', 'exec', '--continue', '--'] + entrypoint
 
     # Configure our image build. If the file in live_update.sync (.tiltbuild/bin/$binary) changes, Tilt
     # copies it to the running container and restarts it.


### PR DESCRIPTION
If we pass entrypoint as a string - our binary will not receive flags