### PR TITLE
allow duplicates in k8s_yaml

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -120,6 +120,10 @@ def process_yaml(yaml):
             c['image'] = '{}:{}'.format(image_without_tag, command)
 
     # Now apply all the yaml
+    # We are using allow_duplicates=True here as both
+    # operator-controller and catalogd will be installed in the same
+    # namespace "olmv1-system" as of https://github.com/operator-framework/operator-controller/pull/888
+    # and https://github.com/operator-framework/catalogd/pull/283
     k8s_yaml(encode_yaml_stream(objects), allow_duplicates=True)
 
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -120,7 +120,7 @@ def process_yaml(yaml):
             c['image'] = '{}:{}'.format(image_without_tag, command)
 
     # Now apply all the yaml
-    k8s_yaml(encode_yaml_stream(objects))
+    k8s_yaml(encode_yaml_stream(objects), allow_duplicates=True)
 
 
 # data format:


### PR DESCRIPTION
This is because as of https://github.com/operator-framework/operator-controller/pull/888 we are attempting to deploy both operator-controller and catalogd under the same namespace but both projects create the same namespace resulting in an issue with Tilt