### PR TITLE
chore: bump go version to 1.23

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -14,7 +14,7 @@ def deploy_cert_manager_if_needed():
 docker_build(
     ref='helper',
     context='.',
-    build_args={'GO_VERSION': '1.22'},
+    build_args={'GO_VERSION': '1.23'},
     dockerfile_contents='''
 ARG GO_VERSION
 FROM golang:${GO_VERSION}


### PR DESCRIPTION
When using tilt to run operator-controller / catalogd and having latest stable version of go (1.23.4), both controllers end up in a failed state because of the incompatible version of delve defined in tilt-support/Tiltfile builder:

> operator-con… │ [event: pod olmv1-system/operator-controller-controller-manager-778d45c685-vwrxt] Back-off restarting failed container manager in pod operator-controller-controller-manager-778d45c685-vwrxt_olmv1-system(1f47d6f8-6b8e-44c0-a945-ad676e38ad6a)
> ...
> catalogd-con… │ Version of Delve is too old for Go version go1.23.4 (maximum supported version 1.22, suppress this error with --check-go-version=false)

This PR bumps the builder go version to 1.23 which is also used for dlv installation version and does not have compatibility issue.

An alternative solution could be to separate GO_VERSION and DLV_VERSION if the builder go version should not be updated for some reason (I did not found one).